### PR TITLE
Enable Prompt Cache for Claude-3.7-sonnet in OpenRouter

### DIFF
--- a/openhands/llm/llm.py
+++ b/openhands/llm/llm.py
@@ -49,6 +49,7 @@ LLM_RETRY_EXCEPTIONS: tuple[type[Exception], ...] = (
 # remove this when we gemini and deepseek are supported
 CACHE_PROMPT_SUPPORTED_MODELS = [
     'claude-3-7-sonnet-20250219',
+    'claude-3.7-sonnet',
     'claude-sonnet-3-7-latest',
     'claude-3-5-sonnet-20241022',
     'claude-3-5-sonnet-20240620',


### PR DESCRIPTION
Enable Prompt Cache for Claude-3.7-sonnet in OpenRouter

- [ ] This change is worth documenting at https://docs.all-hands.dev/
- [ ] Include this change in the Release Notes. If checked, you **must** provide an **end-user friendly** description for your change below

**End-user friendly description of the problem this fixes or functionality this introduces.**


---
**Summarize what the PR does, explaining any non-trivial design decisions.**


---
**Link of any specific issues this addresses:**
